### PR TITLE
Add Chkk standalone mode

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -20,6 +20,28 @@ jobs:
           kubernetes-manifest: k8s/k8s-manifest.yaml
 ```
 
+
+To use Chkk in Standalone Mode, simply set the `standalone-mode` paramater to `true` as shown in the example below:
+
+```
+name: Example workflow for Chkk Kubernetes Action
+on: push
+jobs:
+  kubernetes-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Chkk to catch reliability risks in your Kubernetes manifests
+        uses: chkk-io/actions/k8s@main
+        env:
+          CHKK_ACCESS_TOKEN: ${{ secrets.CHKK_ACCESS_TOKEN }}
+        with:
+          kubernetes-manifest: ${{ github.workspace }}/sample-manifest.yaml
+          standalone-mode: true
+```
+
+
 The Chkk GitHub Action has properties which are passed to the underlying CLI. These are passed to the action using `with`.
 
 | Parameter           | Default | Description                                                  |
@@ -28,7 +50,7 @@ The Chkk GitHub Action has properties which are passed to the underlying CLI. Th
 | kubernetes-manifest |         | The path to the Kubernetes manifest file you want to check.  |
 | skip-checks         |         | A comma-separated list of checks you want to skip.           |
 | run-checks       |         | A comma-separated list of specific checks you want to run instead of running all checks. |
-| check-type          | reliability | Run specific type of checks. Available options: [all/reliability/security] |
+| check-type          | all | Run specific type of checks. Available options: [all, reliability, security, apideprecation, operatingsystem, livenessreadinessprobe, resourcelimit]|
 
 
 
@@ -38,7 +60,7 @@ List of supported `args`
 
 | Argument            | Default | Description                              |
 | :------------------ | :------ | :--------------------------------------- |
-| --show-diff         | false   | Show line diff in result output               |
+| --show-diff         | false   | Show line diff in result output          |
 | --continue-on-error | false   | Do not raise error in case a check fails |
 
 
@@ -79,6 +101,7 @@ jobs:
 
 ### Show Line Diff for Failed Checks
 To show the line diff for failed checks in the result output, configure the Action with following argument: `--show-diff`
+
 
 ```yaml
 on: [push]
@@ -167,20 +190,23 @@ jobs:
         args: '--continue-on-error'
 ```
 
-### Run Specific Type of Checks (Security/Reliability/All)
+### Run Specific Type of Checks
 
-To run specific types of checks, configure the Action with the following argument: `--check-type` 
+To run specific types of checks, configure the Action with the following argument: `--check-type`
 
 Available options are:
 
+* all (selected as default)
+* reliability
 * security
-* reliability (selected as default)
-* all
+* apideprecation
+* operatingsystem
+* livenessreadinessprobe
+* resourcelimit
 
 
 ```yaml
 on: [push]
-
 jobs:
   kubernetes-manifests:
     runs-on: ubuntu-latest
@@ -194,6 +220,5 @@ jobs:
         kubernetes-manifest: 'k8s/k8s-manifest.yaml'
         args: '--check-type=all'
 ```
-
 
 Made with 🧡 by Chkk

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -23,7 +23,7 @@ jobs:
 
 To use Chkk in Standalone Mode, simply set the `standalone-mode` paramater to `true` as shown in the example below:
 
-```
+```yaml
 name: Example workflow for Chkk Kubernetes Action
 on: push
 jobs:

--- a/k8s/action.yml
+++ b/k8s/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'List of checks to run'
     required: false
     default: "default"
+  standalone-mode:
+    description: 'Use Chkk Standalone Mode'
+    required: false
+    default: "false"
   args:
     description: 'Additional arguments to pass to Chkk'
     required: false
@@ -19,9 +23,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: curl -Lo chkk https://downloads.chkk.dev/v0.0.1/chkk-linux-amd64
-      shell: bash
+    - run: VERSION=$(curl -sS https://get.chkk.dev/cli/latest.txt) && curl -Lo chkk https://get.chkk.dev/${VERSION}/chkk-linux-amd64
+      shell: sh
     - run: chmod +x chkk
-      shell: bash
-    - run: ${{ github.workspace }}/chkk -f ${{ inputs.kubernetes-manifest }} -s ${{ inputs.skip-checks }} -r ${{ inputs.run-checks }} ${{ inputs.args }}
-      shell: bash
+      shell: sh
+    - run: if [ ${{ inputs.standalone-mode }} = true ]; then ./chkk standalone install; fi
+      shell: sh
+    - run: ./chkk -f ${{ inputs.kubernetes-manifest }} -s ${{ inputs.skip-checks }} -r ${{ inputs.enable-checks }} ${{ inputs.args }}
+      shell: sh


### PR DESCRIPTION
## Description

* Add support for Standalone mode in Chkk Github action

## Usage

To use Chkk in Standalone Mode, set the `standalone-mode` paramater to `true` as shown in the example below:

```yaml
name: Example workflow for Chkk Kubernetes Action
on: push
jobs:
  kubernetes-manifests:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v2
      - name: Run Chkk to catch reliability risks in your Kubernetes manifests
        uses: chkk-io/actions/k8s@main
        env:
          CHKK_ACCESS_TOKEN: ${{ secrets.CHKK_ACCESS_TOKEN }}
        with:
          kubernetes-manifest: ${{ github.workspace }}/sample-manifest.yaml
          standalone-mode: true
```